### PR TITLE
Correct 'invalidating the cache' demo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,11 +97,11 @@ Results of cached functions can be invalidated by outside forces. Let's demonstr
     >>> monopoly.boardwalk
     550
     >>> # invalidate the cache
-    >>> del m.boardwalk
+    >>> del monopoly.boardwalk
     >>> # request the boardwalk property again
-    >>> m.boardwalk
+    >>> monopoly.boardwalk
     600
-    >>> m.boardwalk
+    >>> monopoly.boardwalk
     600
 
 Working with Threads


### PR DESCRIPTION
Hi,

The README magicked the variable 'm' out of nowhere; this change assumes it was meant to be 'monopoly' which had already been instantiated.

Cheers!
Darian
