### PR TITLE
Add TTL support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - "pypy"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install pytest
+install: pip install -r requirements.txt --use-mirrors
 
 # command to run tests, e.g. python setup.py test
 script: py.test

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@
 coverage
 pytest
 pytest-cov
+freezegun
 wheel==0.23.0

--- a/tests/test_cached_property.py
+++ b/tests/test_cached_property.py
@@ -30,7 +30,7 @@ class TestCachedProperty(unittest.TestCase):
                 self.total1 += 1
                 return self.total1
 
-            @cached_property()
+            @cached_property
             def add_cached(self):
                 self.total2 += 1
                 return self.total2
@@ -45,6 +45,10 @@ class TestCachedProperty(unittest.TestCase):
         self.assertEqual(c.add_cached, 1)
         self.assertEqual(c.add_cached, 1)
 
+        # Cannot expire the cache.
+        with freeze_time("9999-01-01"):
+            self.assertEqual(c.add_cached, 1)
+
         # It's customary for descriptors to return themselves if accessed
         # though the class, rather than through an instance.
         self.assertTrue(isinstance(Check.add_cached, cached_property))
@@ -56,7 +60,7 @@ class TestCachedProperty(unittest.TestCase):
             def __init__(self):
                 self.total = 0
 
-            @cached_property()
+            @cached_property
             def add_cached(self):
                 self.total += 1
                 return self.total
@@ -79,7 +83,7 @@ class TestCachedProperty(unittest.TestCase):
             def __init__(self):
                 self.total = None
 
-            @cached_property()
+            @cached_property
             def add_cached(self):
                 return self.total
 
@@ -102,7 +106,7 @@ class TestThreadingIssues(unittest.TestCase):
                 self.total = 0
                 self.lock = Lock()
 
-            @cached_property()
+            @cached_property
             def add_cached(self):
                 sleep(1)
                 # Need to guard this since += isn't atomic.
@@ -134,6 +138,7 @@ class TestThreadingIssues(unittest.TestCase):
 
 
 class TestCachedPropertyWithTTL(unittest.TestCase):
+
     def test_ttl_expiry(self):
 
         class Check(object):

--- a/tests/test_threaded_cached_property.py
+++ b/tests/test_threaded_cached_property.py
@@ -29,7 +29,7 @@ class TestCachedProperty(unittest.TestCase):
                 self.total1 += 1
                 return self.total1
 
-            @threaded_cached_property
+            @threaded_cached_property()
             def add_cached(self):
                 self.total2 += 1
                 return self.total2
@@ -51,7 +51,7 @@ class TestCachedProperty(unittest.TestCase):
             def __init__(self):
                 self.total = 0
 
-            @threaded_cached_property
+            @threaded_cached_property()
             def add_cached(self):
                 self.total += 1
                 return self.total
@@ -63,7 +63,7 @@ class TestCachedProperty(unittest.TestCase):
         self.assertEqual(c.add_cached, 1)
 
         # Reset the cache.
-        del c.add_cached
+        del c._cache['add_cached']
         self.assertEqual(c.add_cached, 2)
         self.assertEqual(c.add_cached, 2)
 
@@ -74,7 +74,7 @@ class TestCachedProperty(unittest.TestCase):
             def __init__(self):
                 self.total = None
 
-            @threaded_cached_property
+            @threaded_cached_property()
             def add_cached(self):
                 return self.total
 
@@ -95,7 +95,7 @@ class TestThreadingIssues(unittest.TestCase):
                 self.total = 0
                 self.lock = Lock()
 
-            @threaded_cached_property
+            @threaded_cached_property()
             def add_cached(self):
                 sleep(1)
                 # Need to guard this since += isn't atomic.

--- a/tests/test_threaded_cached_property.py
+++ b/tests/test_threaded_cached_property.py
@@ -29,7 +29,7 @@ class TestCachedProperty(unittest.TestCase):
                 self.total1 += 1
                 return self.total1
 
-            @threaded_cached_property()
+            @threaded_cached_property
             def add_cached(self):
                 self.total2 += 1
                 return self.total2
@@ -51,7 +51,7 @@ class TestCachedProperty(unittest.TestCase):
             def __init__(self):
                 self.total = 0
 
-            @threaded_cached_property()
+            @threaded_cached_property
             def add_cached(self):
                 self.total += 1
                 return self.total
@@ -74,7 +74,7 @@ class TestCachedProperty(unittest.TestCase):
             def __init__(self):
                 self.total = None
 
-            @threaded_cached_property()
+            @threaded_cached_property
             def add_cached(self):
                 return self.total
 
@@ -95,7 +95,7 @@ class TestThreadingIssues(unittest.TestCase):
                 self.total = 0
                 self.lock = Lock()
 
-            @threaded_cached_property()
+            @threaded_cached_property
             def add_cached(self):
                 sleep(1)
                 # Need to guard this since += isn't atomic.


### PR DESCRIPTION
This pull request implemented timed cache support for `cached property`.

The syntax is same as #4. The only limitation is when invalidting the cahce, you have to write:

```python
del c._cache['cached_prop']
```

instead of plain `del c.cached_prop`.

Also related to #13.