### PR TITLE
Facade for all cached property variants

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,18 +51,18 @@ Now run it:
     >>> monopoly.boardwalk
     600
 
-Let's convert the boardwalk property into a ``cached_property``.
+Let's convert the boardwalk property into a ``cachedproperty``.
 
 .. code-block:: python
 
-    from cached_property import cached_property
+    from cached_property import cachedproperty
 
     class Monopoly(object):
 
         def __init__(self):
             self.boardwalk_price = 500
 
-        @cached_property
+        @cachedproperty
         def boardwalk(self):
             # Again, this is a silly example. Don't worry about it, this is
             #   just an example for clarity.
@@ -96,7 +96,7 @@ Results of cached functions can be invalidated by outside forces. Let's demonstr
     >>> monopoly.boardwalk
     550
     >>> # invalidate the cache
-    >>> del monopoly['boardwalk']
+    >>> del monopoly.boardwalk
     >>> # request the boardwalk property again
     >>> monopoly.boardwalk
     600
@@ -107,14 +107,14 @@ Working with Threads
 ---------------------
 
 What if a whole bunch of people want to stay at Boardwalk all at once? This means using threads, which
-unfortunately causes problems with the standard ``cached_property``. In this case, switch to using the
-``threaded_cached_property``:
+unfortunately causes problems with the standard ``cachedproperty``. In this case, pass
+``threadsafe=True``:
 
 .. code-block:: python
 
     import threading
 
-    from cached_property import threaded_cached_property
+    from cached_property import cachedproperty
 
     class Monopoly(object):
 
@@ -122,12 +122,13 @@ unfortunately causes problems with the standard ``cached_property``. In this cas
             self.boardwalk_price = 500
             self.lock = threading.Lock()
 
-        @threaded_cached_property
+        @cachedproperty(threadsafe=True)
         def boardwalk(self):
-            """threaded_cached_property is really nice for when no one waits
-                for other people to finish their turn and rudely start rolling
-                dice and moving their pieces."""
-
+            """
+            threadsafe=True is really nice for when no one waits for other
+            people to finish their turn and rudely start rolling dice and
+            moving their pieces.
+            """
             sleep(1)
             # Need to guard this since += isn't atomic.
             with self.lock:
@@ -156,17 +157,17 @@ Now use it:
 Timing out the cache
 --------------------
 
-Sometimes you want the price of things to reset after a time. Use the ``ttl``
-versions of ``cached_property`` and ``threaded_cached_property``.
+Sometimes you want the price of things to reset after a time. In such cases you
+can pass ``ttl``:
 
 .. code-block:: python
 
     import random
-    from cached_property import cached_property_with_ttl
+    from cached_property import cachedproperty
 
     class Monopoly(object):
 
-        @cached_property_with_ttl(ttl=5) # cache invalidates after 5 seconds
+        @cachedproperty(ttl=5) # cache invalidates after 5 seconds
         def dice(self):
             # I dare the reader to implement a game using this method of 'rolling dice'.
             return random.randint(2,12)
@@ -187,8 +188,6 @@ Now use it:
     >>> monopoly.dice
     3
 
-**Note:** The ``ttl`` tools do not reliably allow the clearing of the cache. This
-is why they are broken out into seperate tools. See https://github.com/pydanny/cached-property/issues/16.
 
 Credits
 --------

--- a/cached_property.py
+++ b/cached_property.py
@@ -9,6 +9,50 @@ from time import time
 import threading
 
 
+def cachedproperty(func=None, ttl=None, threadsafe=False):
+    """
+    A property that is computed at most once per instance and then replaces
+    itself with an ordinary attribute. Deleting the attribute resets the
+    property. Usage:
+
+        class Stuff(object):
+
+            # A cached property can be defined as a decorator
+            @cachedproperty
+            def foo(self):
+                ...
+
+            # ... or a decorator factory:
+            @cachedproperty(ttl=1)
+            def bar(self):
+                ...
+
+            # or explicitly by a function call:
+
+            def baz(self):
+                ...
+
+            cached_baz = cachedproperty(baz, threadsafe=True)
+
+    :param ttl: Max time (in seconds) the property can stay cached. By default
+        cached properties don't expire unless explicitly deleted.
+    :param threadsafe: Pass True if the property might be accessed concurrently
+        by multiple threads.
+    """
+    if ttl is None:
+        if not threadsafe:
+            decorator = cached_property
+        else:
+            decorator = threaded_cached_property
+    else:
+        if not threadsafe:
+            decorator = cached_property_with_ttl(ttl)
+        else:
+            decorator = threaded_cached_property_with_ttl(ttl)
+
+    return decorator(func) if func is not None else decorator
+
+
 class cached_property(object):
     """
     A property that is only computed once per instance and then replaces itself

--- a/cached_property.py
+++ b/cached_property.py
@@ -27,15 +27,14 @@ class cached_property(object):
         return value
 
 
-class threaded_cached_property(object):
+class threaded_cached_property(cached_property):
     """
     A cached_property version for use in environments where multiple threads
     might concurrently try to access the property.
     """
 
     def __init__(self, func):
-        self.__doc__ = getattr(func, '__doc__')
-        self.func = func
+        super(threaded_cached_property, self).__init__(func)
         self.lock = threading.RLock()
 
     def __get__(self, obj, cls):

--- a/tests/test_cached_property.py
+++ b/tests/test_cached_property.py
@@ -53,7 +53,11 @@ def CheckFactory(cached_property_decorator, threadsafe=False):
 class TestCachedProperty(unittest.TestCase):
     """Tests for cached_property"""
 
-    cached_property_factory = cached_property.cached_property
+    cached_property_type = cached_property.cached_property
+
+    @property
+    def cached_property_decorator(self):
+        return cached_property.cachedproperty()
 
     def assert_control(self, check, expected):
         """
@@ -70,7 +74,7 @@ class TestCachedProperty(unittest.TestCase):
         self.assertEqual(check.cached_total, expected)
 
     def test_cached_property(self):
-        Check = CheckFactory(self.cached_property_factory)
+        Check = CheckFactory(self.cached_property_decorator)
         check = Check()
 
         # The control shows that we can continue to add 1
@@ -81,17 +85,12 @@ class TestCachedProperty(unittest.TestCase):
         self.assert_cached(check, 1)
         self.assert_cached(check, 1)
 
-        # The cache does not expire
-        with freeze_time("9999-01-01"):
-            self.assert_cached(check, 1)
-
         # Typically descriptors return themselves if accessed though the class
         # rather than through an instance.
-        self.assertTrue(isinstance(Check.add_cached,
-                                   self.cached_property_factory))
+        self.assertEqual(type(Check.add_cached), self.cached_property_type)
 
     def test_reset_cached_property(self):
-        Check = CheckFactory(self.cached_property_factory)
+        Check = CheckFactory(self.cached_property_decorator)
         check = Check()
 
         # Run standard cache assertion
@@ -111,21 +110,21 @@ class TestCachedProperty(unittest.TestCase):
             def __init__(self):
                 self.cached_total = None
 
-            @self.cached_property_factory
+            @self.cached_property_decorator
             def add_cached(self):
                 return self.cached_total
 
         self.assert_cached(Check(), None)
 
     def test_set_cached_property(self):
-        Check = CheckFactory(self.cached_property_factory)
+        Check = CheckFactory(self.cached_property_decorator)
         check = Check()
         check.add_cached = 'foo'
         self.assertEqual(check.add_cached, 'foo')
         self.assertEqual(check.cached_total, 0)
 
     def test_threads(self):
-        Check = CheckFactory(self.cached_property_factory, threadsafe=True)
+        Check = CheckFactory(self.cached_property_decorator, threadsafe=True)
         check = Check()
         num_threads = 5
 
@@ -140,24 +139,72 @@ class TestCachedProperty(unittest.TestCase):
         self.assert_cached(check, num_threads)
         self.assert_cached(check, num_threads)
 
+    def test_ttl_expiry(self):
+        Check = CheckFactory(self.cached_property_decorator)
+        check = Check()
+
+        # The cache does not expire
+        with freeze_time("9999-01-01"):
+            self.assert_cached(check, 1)
+
+        # Things are not reverted when we are back to the present
+        self.assert_cached(check, 1)
+        self.assert_cached(check, 1)
+
+    def test_threads_ttl_expiry(self):
+        Check = CheckFactory(self.cached_property_decorator, threadsafe=True)
+        check = Check()
+        num_threads = 5
+
+        # Same as in test_threads
+        check.run_threads(num_threads)
+        self.assert_cached(check, num_threads)
+        self.assert_cached(check, num_threads)
+
         # The cache does not expire
         with freeze_time("9999-01-01"):
             check.run_threads(num_threads)
             self.assert_cached(check, num_threads)
             self.assert_cached(check, num_threads)
 
+        # Things are not reverted when we are back to the present
+        self.assert_cached(check, num_threads)
+        self.assert_cached(check, num_threads)
+
+
+class TestCachedProperty2(TestCachedProperty):
+    """@cachedproperty is equivalent to @cachedproperty()"""
+
+    @property
+    def cached_property_decorator(self):
+        return cached_property.cachedproperty
+
 
 class TestThreadedCachedProperty(TestCachedProperty):
     """Tests for threaded_cached_property"""
 
-    cached_property_factory = cached_property.threaded_cached_property
+    cached_property_type = cached_property.threaded_cached_property
+
+    @property
+    def cached_property_decorator(self):
+        return cached_property.cachedproperty(threadsafe=True)
 
     def test_threads(self):
-        Check = CheckFactory(self.cached_property_factory, threadsafe=True)
+        Check = CheckFactory(self.cached_property_decorator, threadsafe=True)
         check = Check()
         num_threads = 5
 
         # threaded_cached_property_with_ttl is thread-safe
+        check.run_threads(num_threads)
+        self.assert_cached(check, 1)
+        self.assert_cached(check, 1)
+
+    def test_threads_ttl_expiry(self):
+        Check = CheckFactory(self.cached_property_decorator, threadsafe=True)
+        check = Check()
+        num_threads = 5
+
+        # Same as in test_threads
         check.run_threads(num_threads)
         self.assert_cached(check, 1)
         self.assert_cached(check, 1)
@@ -168,14 +215,22 @@ class TestThreadedCachedProperty(TestCachedProperty):
             self.assert_cached(check, 1)
             self.assert_cached(check, 1)
 
+        # Things are not reverted when we are back to the present
+        self.assert_cached(check, 1)
+        self.assert_cached(check, 1)
+
 
 class TestCachedPropertyWithTTL(TestCachedProperty):
     """Tests for cached_property_with_ttl"""
 
-    cached_property_factory = cached_property.cached_property_with_ttl
+    cached_property_type = cached_property.cached_property_with_ttl
+
+    @property
+    def cached_property_decorator(self):
+        return cached_property.cachedproperty(ttl=100000)
 
     def test_ttl_expiry(self):
-        Check = CheckFactory(self.cached_property_factory(ttl=100000))
+        Check = CheckFactory(self.cached_property_decorator)
         check = Check()
 
         # Run standard cache assertion
@@ -192,8 +247,7 @@ class TestCachedPropertyWithTTL(TestCachedProperty):
         self.assert_cached(check, 2)
 
     def test_threads_ttl_expiry(self):
-        Check = CheckFactory(self.cached_property_factory(ttl=100000),
-                             threadsafe=True)
+        Check = CheckFactory(self.cached_property_decorator, threadsafe=True)
         check = Check()
         num_threads = 5
 
@@ -217,11 +271,14 @@ class TestThreadedCachedPropertyWithTTL(TestThreadedCachedProperty,
                                         TestCachedPropertyWithTTL):
     """Tests for threaded_cached_property_with_ttl"""
 
-    cached_property_factory = cached_property.threaded_cached_property_with_ttl
+    cached_property_type = cached_property.threaded_cached_property_with_ttl
+
+    @property
+    def cached_property_decorator(self):
+        return cached_property.cachedproperty(ttl=100000, threadsafe=True)
 
     def test_threads_ttl_expiry(self):
-        Check = CheckFactory(self.cached_property_factory(ttl=100000),
-                             threadsafe=True)
+        Check = CheckFactory(self.cached_property_decorator, threadsafe=True)
         check = Check()
         num_threads = 5
 


### PR DESCRIPTION
This PR hides all the various cached property implementations behind a single `cachedproperty` callable, which is easier to read, write and extend with more options in the future. I picked this name instead of `cached_property` to avoid the potential backwards incompatibility (in case some code out there relies on it being a descriptor class instead of a function) and also to be similar to `staticmethod` and `classmethod` that don't use underscores either, but I don't mind renaming to something else if you prefer.
