### PR TITLE
drop some non-ASCII characters from HISTORY.rst

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,7 +14,7 @@ History
 1.1.0 (2015-04-04)
 ++++++++++++++++++
 
-* Regression: As the cache was not always clearing, we’ve broken out the time to expire feature to it’s own set of specific tools, thanks to @pydanny
+* Regression: As the cache was not always clearing, we've broken out the time to expire feature to its own set of specific tools, thanks to @pydanny
 * Fixed typo in README, thanks to @zoidbergwill
 
 1.0.0 (2015-02-13)


### PR DESCRIPTION
This file was using some odd unicode character instead of a normal apostrophe in a couple of places. Replace one occurrence with a normal apostrophe and remove the other (the possessive "its" does not contain an apostrophe).

This could cause a problem when `setup.py` does this:

    history = open('HISTORY.rst').read().replace('.. :changelog:', '')

In Python 3, when you do `open().read()`, a unicode decode occurs. The 'default' encoding used in this case depends on details of system configuration, for instance the locale. In some cases, it can be ASCII - and so when the file contains non-ASCII characters, this causes a traceback. (This was happening in the Fedora buildsystem; presumably our buildbots don't have a UTF-8 locale).

We could do this:

    history = open('HISTORY.rst', encoding='utf-8').read().replace('.. :changelog:', '')

but that's not valid in Python 2, `open()` does not have the `encoding` argument there. So at that point I figured it was easier to just find the non-ASCII characters and fix those than try and figure out a fix for reading non-ASCII chars that's safe for both Pythons.