### PR TITLE
Correct invalidation cache documentation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Results of cached functions can be invalidated by outside forces. Let's demonstr
     >>> monopoly.boardwalk
     550
     >>> # invalidate the cache
-    >>> del monopoly['boardwalk']
+    >>> del monopoly.__dict__['boardwalk']
     >>> # request the boardwalk property again
     >>> monopoly.boardwalk
     600


### PR DESCRIPTION
This is not the first class world problem but can confuse python newcomers.
```python
>>> monopoly.boardwalk
550
>>> del monopoly['boardwalk']
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'Monopoly' object does not support item deletion
>>> del monopoly.__dict__['boardwalk']
>>> monopoly.boardwalk
600
```