### PR TITLE
Update release dates for 1.4.1 and 1.4.2

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,12 +3,12 @@
 History
 -------
 
-1.4.2 (2018-03-08)
+1.4.2 (2018-04-08)
 ++++++++++++++++++
 
 * Really fixed tests, thanks to @pydanny
 
-1.4.1 (2018-03-08)
+1.4.1 (2018-04-08)
 ++++++++++++++++++
 
 * Added conftest.py to manifest so tests work properly off the tarball, thanks to @dotlambda


### PR DESCRIPTION
I noticed these new versions got released, and was surprised that it had been more than one month ago! Looking at the commit history, I realized it was more likely a typo. 😉 