### PR TITLE
Also catch `SyntaxError` from asyncio import

### DIFF
--- a/cached_property.py
+++ b/cached_property.py
@@ -10,7 +10,7 @@ import threading
 
 try:
     import asyncio
-except ImportError:
+except (ImportError, SyntaxError):
     asyncio = None
 
 


### PR DESCRIPTION
Apparently, `asyncio` is installable in python 2 and an import can trigger this:

```bash
pip install asyncio cached-property
python -c 'import cached_property'
```

```python
$ python -c 'import cached_property'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/private/tmp/venv/lib/python2.7/site-packages/cached_property.py", line 12, in <module>
    import asyncio
  File "/private/tmp/venv/lib/python2.7/site-packages/asyncio/__init__.py", line 9, in <module>
    from . import selectors
  File "/private/tmp/venv/lib/python2.7/site-packages/asyncio/selectors.py", line 39
    "{!r}".format(fileobj)) from None
                               ^
SyntaxError: invalid syntax
```

Originally seen in https://github.com/pre-commit/pre-commit/issues/766