### PR TITLE
use sudo=true and dist: xenial to fix python3.7 travis-ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,17 @@ sudo: false
 language: python
 
 python:
-  - "3.7"  
-  - "3.6"  
+  - "3.6"
   - "3.5"
   - "3.4"
   - "2.7"
   - "pypy"
+
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -r requirements.txt


### PR DESCRIPTION
- use `sudo = true` and `dist: xenial` to fix python3.7 travis-ci build. related to https://github.com/travis-ci/travis-ci/issues/9815#issuecomment-401756442
