### PR TITLE
Include conftest.py in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include LICENSE
 include README.rst
 
 recursive-include tests *
+include conftest.py
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 


### PR DESCRIPTION
This is needed to successfully run the tests on Python 2.7.