### PR TITLE
Inspect and / or delete cached properties

### DIFF
--- a/.ipynb_checkpoints/readme_companion-checkpoint.ipynb
+++ b/.ipynb_checkpoints/readme_companion-checkpoint.ipynb
@@ -1,0 +1,1080 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# How to use it"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:40.866135Z",
+     "start_time": "2020-03-05T16:07:40.860150Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "class MyClass(object):\n",
+    "\n",
+    "    @property\n",
+    "    def my_property(self):\n",
+    "        # In reality, this might represent a database call or time\n",
+    "        # intensive task like calling a third-party API.\n",
+    "        print('Computing my_property...')  \n",
+    "        return 42"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:40.896052Z",
+     "start_time": "2020-03-05T16:07:40.870124Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object = MyClass()\n",
+    "my_object.my_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:40.904031Z",
+     "start_time": "2020-03-05T16:07:40.898047Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:40.912050Z",
+     "start_time": "2020-03-05T16:07:40.906027Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from cached_property import cached_property\n",
+    "\n",
+    "class MyClass(object):\n",
+    "\n",
+    "    @cached_property\n",
+    "    def my_cached_property(self):\n",
+    "        print('Computing my_cached_property...')\n",
+    "        return 42"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:40.923034Z",
+     "start_time": "2020-03-05T16:07:40.914005Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object = MyClass()\n",
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:40.930992Z",
+     "start_time": "2020-03-05T16:07:40.924977Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Inspecting the cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:40.940933Z",
+     "start_time": "2020-03-05T16:07:40.932954Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from cached_property import cached_property, cached_properties, is_cached"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:40.948911Z",
+     "start_time": "2020-03-05T16:07:40.942927Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "class MyClass(object):\n",
+    "\n",
+    "    @cached_property\n",
+    "    def my_cached_property(self):\n",
+    "        print('Computing my_cached_property...')\n",
+    "        return 42\n",
+    "    \n",
+    "    @cached_property\n",
+    "    def my_second_cached_property(self):\n",
+    "        print('Computing my_second_cached_property...')\n",
+    "        return 51"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:40.956891Z",
+     "start_time": "2020-03-05T16:07:40.950906Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "my_object = MyClass()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:40.965899Z",
+     "start_time": "2020-03-05T16:07:40.958885Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "my_cached_property\n",
+      "my_second_cached_property\n"
+     ]
+    }
+   ],
+   "source": [
+    "for property_name in cached_properties(my_object):\n",
+    "    print(property_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:40.977835Z",
+     "start_time": "2020-03-05T16:07:40.967861Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:40.985813Z",
+     "start_time": "2020-03-05T16:07:40.978832Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_cached(my_object, 'my_cached_property')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:40.997781Z",
+     "start_time": "2020-03-05T16:07:40.988807Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_cached(my_object, 'my_second_cached_property')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Invalidating the cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.005760Z",
+     "start_time": "2020-03-05T16:07:40.998778Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from cached_property import cached_property, un_cache, delete_cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.015734Z",
+     "start_time": "2020-03-05T16:07:41.007754Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "class MyClass(object):\n",
+    "\n",
+    "    @cached_property\n",
+    "    def my_cached_property(self):\n",
+    "        print('Computing my_cached_property...')\n",
+    "        return 42\n",
+    "    \n",
+    "    @cached_property\n",
+    "    def my_second_cached_property(self):\n",
+    "        print('Computing my_second_cached_property...')\n",
+    "        return 51"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.025707Z",
+     "start_time": "2020-03-05T16:07:41.017728Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "my_object = MyClass()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.035680Z",
+     "start_time": "2020-03-05T16:07:41.026705Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.044655Z",
+     "start_time": "2020-03-05T16:07:41.037687Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_second_cached_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "51"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_second_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.054632Z",
+     "start_time": "2020-03-05T16:07:41.047648Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "un_cache(my_object, 'my_cached_property')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.067596Z",
+     "start_time": "2020-03-05T16:07:41.058620Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.077568Z",
+     "start_time": "2020-03-05T16:07:41.069590Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "51"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_second_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.086583Z",
+     "start_time": "2020-03-05T16:07:41.079562Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "delete_cache(my_object)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.097515Z",
+     "start_time": "2020-03-05T16:07:41.088538Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.107488Z",
+     "start_time": "2020-03-05T16:07:41.098512Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_second_cached_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "51"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_second_cached_property"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Property deleting the cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.115466Z",
+     "start_time": "2020-03-05T16:07:41.108485Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from cached_property import cached_property, property_deleting_cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.124442Z",
+     "start_time": "2020-03-05T16:07:41.116463Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "class MyClass(object):\n",
+    "\n",
+    "    def __init__(self, my_parameter):\n",
+    "        self.my_parameter = my_parameter\n",
+    "    \n",
+    "    @property_deleting_cache\n",
+    "    def my_parameter(self):\n",
+    "        \"A parameter that deletes the cache when set or deleted.\"\n",
+    "        print('Accessing my_parameter...')\n",
+    "        \n",
+    "    @cached_property\n",
+    "    def my_cached_property(self):\n",
+    "        print('Computing my_cached_property...')\n",
+    "        return self.my_parameter + 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.136422Z",
+     "start_time": "2020-03-05T16:07:41.125440Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n",
+      "Accessing my_parameter...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object = MyClass(my_parameter=41)\n",
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.145387Z",
+     "start_time": "2020-03-05T16:07:41.138405Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.154370Z",
+     "start_time": "2020-03-05T16:07:41.146384Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n",
+      "Accessing my_parameter...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "51"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_parameter = 50\n",
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.163339Z",
+     "start_time": "2020-03-05T16:07:41.156358Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "51"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Working with Threads"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.172316Z",
+     "start_time": "2020-03-05T16:07:41.165334Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from cached_property import threaded_cached_property\n",
+    "\n",
+    "class MyClass(object):\n",
+    "\n",
+    "    @threaded_cached_property\n",
+    "    def my_cached_property(self):\n",
+    "        print('Computing my_cached_property...')\n",
+    "        return 42"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.187282Z",
+     "start_time": "2020-03-05T16:07:41.173313Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n"
+     ]
+    }
+   ],
+   "source": [
+    "from threading import Thread\n",
+    "my_object = MyClass()\n",
+    "threads = []\n",
+    "for x in range(10):\n",
+    "    thread = Thread(target=lambda: my_object.my_cached_property)\n",
+    "    thread.start()\n",
+    "    threads.append(thread)\n",
+    "\n",
+    "for thread in threads:\n",
+    "    thread.join()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Working with async/await (Python 3.5+)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.194255Z",
+     "start_time": "2020-03-05T16:07:41.189269Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# This is just a trick to make asyncio work in jupyter.\n",
+    "# Cf. https://markhneedham.com/blog/2019/05/10/jupyter-runtimeerror-this-event-loop-is-already-running/\n",
+    "import nest_asyncio\n",
+    "nest_asyncio.apply()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.202234Z",
+     "start_time": "2020-03-05T16:07:41.195252Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from cached_property import cached_property\n",
+    "\n",
+    "class MyClass(object):\n",
+    "\n",
+    "    @cached_property\n",
+    "    async def my_cached_property(self):\n",
+    "        print('Computing my_cached_property...')\n",
+    "        return 42"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.213205Z",
+     "start_time": "2020-03-05T16:07:41.204229Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n",
+      "42\n",
+      "42\n",
+      "42\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def print_my_cached_property():\n",
+    "    my_object = MyClass()\n",
+    "    print(await my_object.my_cached_property)\n",
+    "    print(await my_object.my_cached_property)\n",
+    "    print(await my_object.my_cached_property)\n",
+    "import asyncio\n",
+    "asyncio.get_event_loop().run_until_complete(print_my_cached_property())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Timing out the cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.221185Z",
+     "start_time": "2020-03-05T16:07:41.215199Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "from cached_property import cached_property_with_ttl\n",
+    "\n",
+    "class MyClass(object):\n",
+    "\n",
+    "    @cached_property_with_ttl(ttl=2) # cache invalidates after 2 seconds\n",
+    "    def my_cached_property(self):\n",
+    "        return random.random()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.230161Z",
+     "start_time": "2020-03-05T16:07:41.223179Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "my_object = MyClass()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.242128Z",
+     "start_time": "2020-03-05T16:07:41.232154Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.4770410300930312"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:41.255093Z",
+     "start_time": "2020-03-05T16:07:41.244123Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.4770410300930312"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:44.264416Z",
+     "start_time": "2020-03-05T16:07:41.257088Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from time import sleep\n",
+    "sleep(3)  # Sleeps long enough to expire the cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:07:44.287350Z",
+     "start_time": "2020-03-05T16:07:44.272390Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.259086428146758"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/cached_property.py
+++ b/cached_property.py
@@ -15,7 +15,13 @@ except (ImportError, SyntaxError):
     asyncio = None
 
 
-class cached_property(object):
+class CachedProperty(object):
+    """Parent class for cached properties."""
+    # As of now, it is only used for ``isinstance`` tests. Cf. ``cached_properties_names``.
+    pass
+
+
+class cached_property(CachedProperty):
     """
     A property that is only computed once per instance and then replaces itself
     with an ordinary attribute. Deleting the attribute resets the property.
@@ -47,7 +53,7 @@ class cached_property(object):
         return wrapper()
 
 
-class threaded_cached_property(object):
+class threaded_cached_property(CachedProperty):
     """
     A cached_property version for use in environments where multiple threads
     might concurrently try to access the property.
@@ -74,7 +80,7 @@ class threaded_cached_property(object):
                 return obj_dict.setdefault(name, self.func(obj))
 
 
-class cached_property_with_ttl(object):
+class cached_property_with_ttl(CachedProperty):
     """
     A property that is only computed once per instance and then replaces itself
     with an ordinary attribute. Setting the ttl to a number expresses how long
@@ -151,3 +157,208 @@ class threaded_cached_property_with_ttl(cached_property_with_ttl):
 # Alias to make threaded_cached_property_with_ttl easier to use
 threaded_cached_property_ttl = threaded_cached_property_with_ttl
 timed_threaded_cached_property = threaded_cached_property_with_ttl
+
+
+def all_members(cls):
+    """All members of a class.
+
+    Credit: Jürgen Hermann, Alex Martelli. From
+    https://www.oreilly.com/library/view/python-cookbook/0596001673/ch05s03.html.
+
+
+    Parameters
+    ----------
+    cls : class
+
+    Returns
+    -------
+    dict
+        Similar to ``cls.__dict__``, but include also the inherited members.
+
+    Examples
+    --------
+    >>> class Parent(object):
+    ...     attribute_parent = 42
+    >>> class Child(Parent):
+    ...     attribute_child = 51
+    >>> 'attribute_child' in all_members(Child).keys()
+    True
+    >>> 'attribute_parent' in all_members(Child).keys()
+    True
+    """
+    try:
+        # Try getting all relevant classes in method-resolution order
+        mro = list(cls.__mro__)
+    except AttributeError:
+        # If a class has no _ _mro_ _, then it's a classic class
+        def getmro(a_class, recurse):
+            an_mro = [a_class]
+            for base in a_class.__bases__:
+                an_mro.extend(recurse(base, recurse))
+            return an_mro
+        mro = getmro(cls, getmro)
+    mro.reverse()
+    members = {}
+    for someClass in mro:
+        members.update(vars(someClass))
+    return members
+
+
+def cached_properties(o):
+    """Cached properties (whether already computed or not).
+
+    Parameters
+    ----------
+    o : object
+
+    Yields
+    ------
+    str
+        Name of each cached property.
+
+    Examples
+    --------
+    >>> class MyClass(object):
+    ...     @cached_property
+    ...     def my_cached_property(self):
+    ...         print('Computing my_cached_property...')
+    ...         return 2
+    ...     @cached_property
+    ...     def my_second_cached_property(self):
+    ...         print('Computing my_second_cached_property...')
+    ...         return 3
+    >>> my_object = MyClass()
+    >>> my_object.my_cached_property
+    Computing my_cached_property...
+    2
+    >>> for name in cached_properties(my_object):
+    ...     print(name)
+    my_cached_property
+    my_second_cached_property
+    """
+    return (k for k, v in all_members(o.__class__).items()
+            if isinstance(v, CachedProperty))
+
+
+def cached_properties_computed(o):
+    """Cached properties that are already computed.
+
+    Parameters
+    ----------
+    o : object
+
+    Yields
+    ------
+    str
+        Name of each cached property that is already computed.
+
+    Examples
+    --------
+    >>> class MyClass(object):
+    ...     @cached_property
+    ...     def my_cached_property(self):
+    ...         print('Computing my_cached_property...')
+    ...         return 2
+    ...     @cached_property
+    ...     def my_second_cached_property(self):
+    ...         print('Computing my_second_cached_property...')
+    ...         return 3
+    >>> my_object = MyClass()
+    >>> my_object.my_cached_property
+    Computing my_cached_property...
+    2
+    >>> for name in cached_properties_computed(my_object):
+    ...     print(name)
+    my_cached_property
+    """
+    return (k for k in cached_properties(o) if k in o.__dict__.keys())
+
+
+def delete_cache(o):
+    """Delete the cache.
+
+    Parameters
+    ----------
+    o : object
+
+    Examples
+    --------
+    >>> class MyClass(object):
+    ...     @cached_property
+    ...     def my_cached_property(self):
+    ...         print('Computing my_cached_property...')
+    ...         return 2
+    ...     @cached_property
+    ...     def my_second_cached_property(self):
+    ...         print('Computing my_second_cached_property...')
+    ...         return 3
+    >>> my_object = MyClass()
+    >>> my_object.my_cached_property
+    Computing my_cached_property...
+    2
+    >>> delete_cache(my_object)
+    >>> my_object.my_cached_property
+    Computing my_cached_property...
+    2
+    """
+    for cached_property_name in cached_properties(o):
+        try:
+            del o.__dict__[cached_property_name]
+        except KeyError:
+            pass
+
+
+class property_deleting_cache:
+    """Define a property that deletes the cache when set or deleted.
+
+    Parameters
+    ----------
+    func : function
+        The code of the function is not used, only its docstring.
+
+    Returns
+    -------
+    property
+        A property with get, set and delete. When it is set or deleted,
+        it deletes the cache of the object it belongs to.
+
+    Examples
+    --------
+    >>> class MyClass(object):
+    ...     def __init__(self, my_parameter):
+    ...         self.my_parameter = my_parameter
+    ...     @property_deleting_cache
+    ...     def my_parameter(self):
+    ...         "A parameter that deletes the cache when set or deleted."
+    ...         pass
+    ...     @cached_property
+    ...     def my_cached_property(self):
+    ...         print('Computing my_cached_property...')
+    ...         return self.my_parameter + 1
+    >>> my_object = MyClass(my_parameter=41)
+    >>> my_object.my_cached_property
+    Computing my_cached_property...
+    42
+    >>> my_object.my_parameter = 50
+    >>> my_object.my_cached_property
+    Computing my_cached_property...
+    51
+    >>> MyClass.my_parameter.__doc__
+    'A parameter that deletes the cache when set or deleted.'
+    """
+    def __init__(self, func):
+        self.__doc__ = getattr(func, "__doc__")
+        self.func = func
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            return self
+        return self.value
+
+    def __set__(self, obj, value):
+        delete_cache(obj)
+        self.value = value
+
+    def __delete__(self, obj):
+        delete_cache(obj)
+        del self.value

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,3 @@
-
 import sys
 
 # Whether "import asyncio" works

--- a/readme_companion.ipynb
+++ b/readme_companion.ipynb
@@ -1,0 +1,1080 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# How to use it"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.028323Z",
+     "start_time": "2020-03-05T16:34:58.022338Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "class MyClass(object):\n",
+    "\n",
+    "    @property\n",
+    "    def my_property(self):\n",
+    "        # In reality, this might represent a database call or time\n",
+    "        # intensive task like calling a third-party API.\n",
+    "        print('Computing my_property...')  \n",
+    "        return 42"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.073202Z",
+     "start_time": "2020-03-05T16:34:58.030318Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object = MyClass()\n",
+    "my_object.my_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.088163Z",
+     "start_time": "2020-03-05T16:34:58.079186Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.116089Z",
+     "start_time": "2020-03-05T16:34:58.095144Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from cached_property import cached_property\n",
+    "\n",
+    "class MyClass(object):\n",
+    "\n",
+    "    @cached_property\n",
+    "    def my_cached_property(self):\n",
+    "        print('Computing my_cached_property...')\n",
+    "        return 42"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.130050Z",
+     "start_time": "2020-03-05T16:34:58.119080Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object = MyClass()\n",
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.140024Z",
+     "start_time": "2020-03-05T16:34:58.132046Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Inspecting the cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.148999Z",
+     "start_time": "2020-03-05T16:34:58.143016Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from cached_property import cached_property, cached_properties, is_cached"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.157986Z",
+     "start_time": "2020-03-05T16:34:58.152990Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "class MyClass(object):\n",
+    "\n",
+    "    @cached_property\n",
+    "    def my_cached_property(self):\n",
+    "        print('Computing my_cached_property...')\n",
+    "        return 42\n",
+    "    \n",
+    "    @cached_property\n",
+    "    def my_second_cached_property(self):\n",
+    "        print('Computing my_second_cached_property...')\n",
+    "        return 51"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.168946Z",
+     "start_time": "2020-03-05T16:34:58.161965Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "my_object = MyClass()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.178919Z",
+     "start_time": "2020-03-05T16:34:58.170941Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "my_cached_property\n",
+      "my_second_cached_property\n"
+     ]
+    }
+   ],
+   "source": [
+    "for property_name in cached_properties(my_object):\n",
+    "    print(property_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.188893Z",
+     "start_time": "2020-03-05T16:34:58.180914Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.197870Z",
+     "start_time": "2020-03-05T16:34:58.190890Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_cached(my_object, 'my_cached_property')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.206845Z",
+     "start_time": "2020-03-05T16:34:58.199864Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_cached(my_object, 'my_second_cached_property')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Invalidating the cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.215823Z",
+     "start_time": "2020-03-05T16:34:58.208839Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from cached_property import cached_property, un_cache, delete_cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.224797Z",
+     "start_time": "2020-03-05T16:34:58.218813Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "class MyClass(object):\n",
+    "\n",
+    "    @cached_property\n",
+    "    def my_cached_property(self):\n",
+    "        print('Computing my_cached_property...')\n",
+    "        return 42\n",
+    "    \n",
+    "    @cached_property\n",
+    "    def my_second_cached_property(self):\n",
+    "        print('Computing my_second_cached_property...')\n",
+    "        return 51"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.233773Z",
+     "start_time": "2020-03-05T16:34:58.226792Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "my_object = MyClass()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.243746Z",
+     "start_time": "2020-03-05T16:34:58.234770Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.252723Z",
+     "start_time": "2020-03-05T16:34:58.245741Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_second_cached_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "51"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_second_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.260701Z",
+     "start_time": "2020-03-05T16:34:58.253721Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "un_cache(my_object, 'my_cached_property')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.270674Z",
+     "start_time": "2020-03-05T16:34:58.262696Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.278653Z",
+     "start_time": "2020-03-05T16:34:58.271674Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "51"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_second_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.286642Z",
+     "start_time": "2020-03-05T16:34:58.279650Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "delete_cache(my_object)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.299597Z",
+     "start_time": "2020-03-05T16:34:58.290621Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.307576Z",
+     "start_time": "2020-03-05T16:34:58.301592Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_second_cached_property...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "51"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_second_cached_property"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Property deleting the cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.314557Z",
+     "start_time": "2020-03-05T16:34:58.309570Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from cached_property import cached_property, property_deleting_cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.322536Z",
+     "start_time": "2020-03-05T16:34:58.316552Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "class MyClass(object):\n",
+    "\n",
+    "    def __init__(self, my_parameter):\n",
+    "        self.my_parameter = my_parameter\n",
+    "    \n",
+    "    @property_deleting_cache\n",
+    "    def my_parameter(self):\n",
+    "        \"A parameter that deletes the cache when set or deleted.\"\n",
+    "        print('Accessing my_parameter...')\n",
+    "        \n",
+    "    @cached_property\n",
+    "    def my_cached_property(self):\n",
+    "        print('Computing my_cached_property...')\n",
+    "        return self.my_parameter + 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.334504Z",
+     "start_time": "2020-03-05T16:34:58.323533Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n",
+      "Accessing my_parameter...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object = MyClass(my_parameter=41)\n",
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.342483Z",
+     "start_time": "2020-03-05T16:34:58.335501Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.351459Z",
+     "start_time": "2020-03-05T16:34:58.344478Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n",
+      "Accessing my_parameter...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "51"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_parameter = 50\n",
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.361432Z",
+     "start_time": "2020-03-05T16:34:58.352455Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "51"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Working with Threads"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.368413Z",
+     "start_time": "2020-03-05T16:34:58.363428Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from cached_property import threaded_cached_property\n",
+    "\n",
+    "class MyClass(object):\n",
+    "\n",
+    "    @threaded_cached_property\n",
+    "    def my_cached_property(self):\n",
+    "        print('Computing my_cached_property...')\n",
+    "        return 42"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.383374Z",
+     "start_time": "2020-03-05T16:34:58.369411Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n"
+     ]
+    }
+   ],
+   "source": [
+    "from threading import Thread\n",
+    "my_object = MyClass()\n",
+    "threads = []\n",
+    "for x in range(10):\n",
+    "    thread = Thread(target=lambda: my_object.my_cached_property)\n",
+    "    thread.start()\n",
+    "    threads.append(thread)\n",
+    "\n",
+    "for thread in threads:\n",
+    "    thread.join()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Working with async/await (Python 3.5+)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.394345Z",
+     "start_time": "2020-03-05T16:34:58.385370Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# This is just a trick to make asyncio work in jupyter.\n",
+    "# Cf. https://markhneedham.com/blog/2019/05/10/jupyter-runtimeerror-this-event-loop-is-already-running/\n",
+    "import nest_asyncio\n",
+    "nest_asyncio.apply()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.402323Z",
+     "start_time": "2020-03-05T16:34:58.396339Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from cached_property import cached_property\n",
+    "\n",
+    "class MyClass(object):\n",
+    "\n",
+    "    @cached_property\n",
+    "    async def my_cached_property(self):\n",
+    "        print('Computing my_cached_property...')\n",
+    "        return 42"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.413302Z",
+     "start_time": "2020-03-05T16:34:58.404317Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing my_cached_property...\n",
+      "42\n",
+      "42\n",
+      "42\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def print_my_cached_property():\n",
+    "    my_object = MyClass()\n",
+    "    print(await my_object.my_cached_property)\n",
+    "    print(await my_object.my_cached_property)\n",
+    "    print(await my_object.my_cached_property)\n",
+    "import asyncio\n",
+    "asyncio.get_event_loop().run_until_complete(print_my_cached_property())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Timing out the cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.420276Z",
+     "start_time": "2020-03-05T16:34:58.415287Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "from cached_property import cached_property_with_ttl\n",
+    "\n",
+    "class MyClass(object):\n",
+    "\n",
+    "    @cached_property_with_ttl(ttl=2) # cache invalidates after 2 seconds\n",
+    "    def my_cached_property(self):\n",
+    "        return random.randint(1, 100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.430248Z",
+     "start_time": "2020-03-05T16:34:58.422269Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "my_object = MyClass()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.439223Z",
+     "start_time": "2020-03-05T16:34:58.431245Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "66"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:34:58.448200Z",
+     "start_time": "2020-03-05T16:34:58.441218Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "66"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:35:01.458856Z",
+     "start_time": "2020-03-05T16:34:58.450195Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from time import sleep\n",
+    "sleep(3)  # Sleeps long enough to expire the cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-03-05T16:35:01.485791Z",
+     "start_time": "2020-03-05T16:35:01.466838Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "45"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_object.my_cached_property"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Hi @pydanny,

Thank you for this package! This pull request addresses issues #32 and #196. Here is a sum-up:

* All cached properties derive from a parent class ``CachedProperty``, so that we can use ``isinstance`` to identify them easily.
* Add function ``cached_properties``: iterate over the cached properties of an object.
* Add function ``is_cached``: whether a cached property is already cached.
* Add function ``un_cache``: empty the cache for a cached property. As @Tinche noted, it avoids exposing an implementation detail.
* Add function ``delete_cache``: empty the whole cache of an object.
* Add decorator ``property_deleting_cache``: a property that deletes the cache when it is set or deleted. A typical example of application is given in the docstring (and in the readme).

For ``property_deleting_cache``, some people may find it strange to have this parameter ``func`` whose output is ignored. As a matter of fact, in most use cases, I guess that its code will be ``pass``. I hesitated a bit and I also implemented another syntax option in ``property_deleting_cache_2``. However, I still prefer option 1 because its usage as a decorator is more similar to what we use for regular properties and cached properties. Tell me which one you prefer (and just remove the other one)!

In the readme, I suggest replacing the running example about monopoly by a more generic example. This monopoly example seemed quite unnatural to me, and I hope that the new one is more telling, even if it is a bit less funny.

This is my first pull request ever so do not hesitate to tell me if I did something wrong :-). Best,

François