### PR TITLE
Avoid nested KeyError exception for threaded_cached_property

### DIFF
--- a/cached_property.py
+++ b/cached_property.py
@@ -70,8 +70,9 @@ class threaded_cached_property(object):
                 return obj_dict[name]
 
             except KeyError:
-                # if not, do the calculation and release the lock
-                return obj_dict.setdefault(name, self.func(obj))
+                pass
+            # if not, do the calculation and release the lock
+            return obj_dict.setdefault(name, self.func(obj))
 
 
 class cached_property_with_ttl(object):


### PR DESCRIPTION
Resolves #260 

Uses similar approach to the `cached_property_with_ttl` decorator.

Using the same example from #260  the exception no longer contains a `KeyError`:

```python
Traceback (most recent call last):
  File "t.py", line 15, in <module>
    m.boardwalk
  File "/Users/spencer.young/repos/cached-property/cached_property.py", line 75, in __get__
    return obj_dict.setdefault(name, self.func(obj))
  File "t.py", line 11, in boardwalk
    self.boardwalk_price += 1/0
ZeroDivisionError: division by zero
```


Hopefully this will reduce confusion for users, such as in situations [like this](https://stackoverflow.com/q/69634198/5747944).