### PR TITLE
Remove Python 2 from  classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",     
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Based on [commit](https://github.com/pydanny/cached-property/commit/f7b6d211c6d1439253ee0ac01898731219bc27e6), we need to remove mention of Python2 at PyPI.